### PR TITLE
Add test checkout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $ cp ~/dotfile/prepare-commit-msg .git/hooks/
 ### Test prepare-commit-msg
 
 ```
+$ git checkout id/000
 $ touch test
 $ git add test
 $ git commit


### PR DESCRIPTION
## この変更はなぜ必要でしたか?

prepareのテストでissueナンバーが挿入されることを実感して欲しかったため．
## この問題にどうやって対処しましたか?

READMEで一旦チェックアウトさせるように記述を変更しました．
## この変更によって影響を受けるものは何ですか?

特になし．
テストした人がちゃんと「ナンバー入っとるな」思うだけ．
