### PR TITLE
Update .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -10,8 +10,6 @@ if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
 fi
 
-# Customize to your needs...
-
 # path設定
 path=($HOME/bin(N-/) /usr/local/go/bin(N-/) $path)
 
@@ -50,9 +48,14 @@ function git() { hub "$@" }
 
 export PATH="$PATH:$HOME/.rvm/bin"
 export PATH="$HOME/.rbenv/bin:$PATH"
-if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi
+export PATH="/opt/homebrew/bin:$PATH"
+export PATH="/opt/homebrew/opt/libpq/bin:$PATH"
+
+### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)
+export PATH="/Users/shohei.takei/.rd/bin:$PATH"
+### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)
+
+eval "$(rbenv init -)"
 eval "$(nodenv init -)"
 eval $(/opt/homebrew/bin/brew shellenv)
 eval "$(direnv hook zsh)"
-export PATH="/opt/homebrew/opt/libpq/bin:$PATH"
-


### PR DESCRIPTION
## この変更はなぜ必要でしたか?

macOSをアップグレードしたら

```
eval "$(rbenv init -)"
eval "$(nodenv init -)"
```

の2つが command not found になるようになってしまったため。

## この問題にどうやって対処しましたか?

```
export PATH="/opt/homebrew/bin:$PATH"
```

を追加して、このPATHを通してから

```
eval "$(rbenv init -)"
eval "$(nodenv init -)"
```

するようにした。

## この変更によって影響を受けるものは何ですか?

特になし。

## 関連するチケット，issueがあれば記載して下さい

特になし。