### PR TITLE
ネオンっぽく光るフォントの設定を入れた

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ $ git clone https://github.com/shyazusa/dotfile.git
 $ cp -rf ~/Documents/GitHub/dotfile/.* ~/.
 ```
 
+### If Use neon-font.css in VS Code
+
+```
+$ cp -rf ~/Documents/GitHub/dotfile/neon-font.css ~/.
+```
+
+1. Install the `Custom CSS and JS Loader` extension
+2. Tell Custom CSS and JS Loader to use the CSS file included with adding an import line to your VS Code settings.json file:
+
+```
+  "vscode_custom_css.imports": [
+    "file:///Users/your_pc_user_name/neon-font.css"
+  ],
+```
+
+3. Run `Reload Custom CSS and JS` in VS Code
+
 ## Use my gitfiles
 
 ```

--- a/neon-font.css
+++ b/neon-font.css
@@ -1,0 +1,6 @@
+* {
+  text-shadow:
+    0 0 5px #A6126A, /* 貴音カラー */
+    0 0 7px #A6126A,
+    0 0 10px #A6126A !important;
+}


### PR DESCRIPTION
## この変更はなぜ必要でしたか?

VS Codeのフォントが光っていなかったから!
基本的にブラウザなどもダークテーマに合わせて文字色、シャドゥを入れてネオンっぽいカラーにしているので、VS Codeも統一したかった。
完全に個人用の設定にはなるが。

## この問題にどうやって対処しましたか?

CSSでフォントを光るように設定できるようにした!

## この変更によって影響を受けるものは何ですか?

VS Code

## 関連するチケット，issueがあれば記載して下さい

N/A