### PR TITLE
Removes Git module from Prezto configuration

### DIFF
--- a/.zpreztorc
+++ b/.zpreztorc
@@ -32,7 +32,6 @@ zstyle ':prezto:load' pmodule \
   'spectrum' \
   'utility' \
   'completion' \
-  'git' \
   'rails' \
   'syntax-highlighting' \
   'history-substring-search' \


### PR DESCRIPTION
## この変更はなぜ必要でしたか?

git管理はVSCode上で行うため、ターミナルに表示する必要がなくなった。
ターミナルを同時にいくつか開いたとき、gitの情報表示が邪魔になるケースがあった。

## この問題にどうやって対処しましたか?

gitの情報をターミナルに表示しないように設定を変更した。

## この変更によって影響を受けるものは何ですか?

特になし。

## 関連するチケット，issueがあれば記載して下さい

N/A